### PR TITLE
Remove comma from tag lists

### DIFF
--- a/themes/casper/layouts/partials/li.html
+++ b/themes/casper/layouts/partials/li.html
@@ -22,7 +22,7 @@
         {{end}}
         {{if .Params.tags }}on
             {{ range $index, $tag := .Params.tags }}
-                {{ if $index }},{{ end }}<a href="{{$baseurl}}tags/{{ $tag | urlize }}/">#{{ $tag }}</a>
+                <a href="{{$baseurl}}tags/{{ $tag | urlize }}/">#{{ $tag }}</a>
             {{ end }}
         {{end}}
         <time class="post-date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">


### PR DESCRIPTION
Newlines in the source code cause an incorrect space to be inserted before the comma:

![screenshot from live](https://user-images.githubusercontent.com/3150328/34478763-621c58ea-efab-11e7-817e-471b75f02bed.png)

IMO makes sense to just remove the comma altogether like this. Looks good to me.